### PR TITLE
Change color strings to an enum to avoid using String compares

### DIFF
--- a/Software/Qduino/Qduino.cpp
+++ b/Software/Qduino/Qduino.cpp
@@ -46,62 +46,50 @@ void qduino::setRGB(int r, int g, int b){
     analogWrite(13, b);
 }
 
-void qduino::setRGB(String color){
-    
-    int intcolor;
-    
-    if(color == "red") { intcolor = 1; }
-    if(color == "green") { intcolor = 2; }
-    if(color == "blue") { intcolor = 3; }
-    if(color == "cyan") { intcolor = 4; }
-    if(color == "pink") { intcolor = 5; }
-    if(color == "white") { intcolor = 6; }
-    if(color == "purple") { intcolor = 7; }
-    if(color == "yellow") { intcolor = 8; }
-    if(color == "orange") { intcolor = 9; }
-    
-    switch (intcolor) {
-        case 1:
+void qduino::setRGB(Color color){
+
+        switch (color) {
+        case RED:
             analogWrite(10, 0);
             analogWrite(11, 255);
             analogWrite(13, 255);
             break;
-        case 2:
+        case GREEN:
             analogWrite(10, 255);
             analogWrite(11, 0);
             analogWrite(13, 255);
             break;
-        case 3:
+        case BLUE:
             analogWrite(10, 255);
             analogWrite(11, 255);
             analogWrite(13, 0);
             break;
-        case 4:
+        case CYAN:
             analogWrite(10, 255);
             analogWrite(11, 0);
             analogWrite(13, 0);
             break;
-        case 5:
+        case PINK:
             analogWrite(10, 109);
             analogWrite(11, 255);
             analogWrite(13, 0);
             break;
-        case 6:
+        case WHITE:
             analogWrite(10, 109);
             analogWrite(11, 0);
             analogWrite(13, 0);
             break;
-        case 7:
+        case PURPLE:
             analogWrite(10, 210);
             analogWrite(11, 255);
             analogWrite(13, 0);
             break;
-        case 8:
+        case YELLOW:
             analogWrite(10, 100);
             analogWrite(11, 0);
             analogWrite(13, 255);
             break;
-        case 9:
+        case ORANGE:
             analogWrite(10, 109);
             analogWrite(11, 150);
             analogWrite(13, 255);

--- a/Software/Qduino/Qduino.h
+++ b/Software/Qduino/Qduino.h
@@ -34,9 +34,21 @@
 class qduino{
     
 public:
+    enum Color : byte {
+        RED = 1,
+        GREEN,
+        BLUE,
+        CYAN,
+        PINK,
+        WHITE,
+        PURPLE,
+        YELLOW,
+        ORANGE
+    };
+
     void setup();
     void setRGB(int r, int g, int b);
-    void setRGB(String color);
+    void setRGB(Color color);
     void rainbow(int duration);
     void ledOff();
     

--- a/Software/Qduino/examples/batteryLeveltoRGB/batteryLeveltoRGB.ino
+++ b/Software/Qduino/examples/batteryLeveltoRGB/batteryLeveltoRGB.ino
@@ -34,19 +34,19 @@ void loop(){
   
   if(charge >= 75) {
     
-    q.setRGB("green");
+    q.setRGB(qduino::GREEN);
     
   } else if(charge >= 50 && charge << 75) {
     
-    q.setRGB("yellow");
+    q.setRGB(qduino::YELLOW);
     
   } else if(charge >= 25 && charge << 50) {
     
-    q.setRGB("orange");
+    q.setRGB(qduino::ORANGE);
     
   } else if(charge << 25) {
     
-    q.setRGB("red");
+    q.setRGB(qduino::RED);
   }
   
   delay(1000);

--- a/Software/Qduino/examples/rgbLED/rgbLED.ino
+++ b/Software/Qduino/examples/rgbLED/rgbLED.ino
@@ -36,39 +36,39 @@ void loop() {
   
   delay(500);
   
-  q.setRGB("red");
+  q.setRGB(qduino::RED);
   
   delay(500);
   
-  q.setRGB("orange");
+  q.setRGB(qduino::ORANGE);
   
   delay(500);
   
-  q.setRGB("yellow");
+  q.setRGB(qduino::YELLOW);
 
   delay(500);
   
-  q.setRGB("green");
+  q.setRGB(qduino::GREEN);
   
   delay(500);
   
-  q.setRGB("cyan");
+  q.setRGB(qduino::CYAN);
   
   delay(500);
   
-  q.setRGB("blue");
+  q.setRGB(qduino::BLUE);
   
   delay(500);
   
-  q.setRGB("purple");
+  q.setRGB(qduino::PURPLE);
   
   delay(500);
   
-  q.setRGB("pink");
+  q.setRGB(qduino::PINK);
   
   delay(500);
   
-  q.setRGB("white");
+  q.setRGB(qduino::WHITE);
   
   delay(500);
   


### PR DESCRIPTION
I changed the way that the library identifies colors. Now they are an enum, as opposed to a string. Some of the immediate benefits that I can think of:

-Typos are noticed by the compiler at compile time (no having to figure out why code isn't working when you typed "blu" instead of "blue" using the current function)
-The switch statement is easier to read
-No string passing or comparison means faster speed (marginally, but it adds up)
